### PR TITLE
Check wrangling state for dcp url

### DIFF
--- a/src/app/projects/projects.service.ts
+++ b/src/app/projects/projects.service.ts
@@ -35,7 +35,7 @@ export class ProjectsService {
     try {
       return {
         uuid: obj.uuid.uuid,
-        dcpUrl: obj.dcp_url,
+        dcpUrl: obj.wranglingState === 'Published in DCP' && `https://data.humancellatlas.org/explore/projects/${obj.uuid.uuid}`,
         addedToIndex: obj.cataloguedDate,
         date: obj.cataloguedDate ? this.formatDate(obj.cataloguedDate) : '-',
         title: obj.content.project_core.project_title,


### PR DESCRIPTION
Uses the wrangling state to check if a project is in DCP and populates the link accordingly. The script in ticket [#284](https://app.zenhub.com/workspaces/dcp-ingest-product-development-5f71ca62a3cb47326bdc1b5c/issues/ebi-ait/dcp-ingest-central/284) will be updated to auto populate this