### PR TITLE
Don't show undefined when there's no authors

### DIFF
--- a/src/app/projects/components/author-names/author-names.component.ts
+++ b/src/app/projects/components/author-names/author-names.component.ts
@@ -10,7 +10,7 @@ export class AuthorNamesComponent implements OnInit {
   @Input()
   authors: Author[];
 
-  fullAuthorView: boolean = false;
+  fullAuthorView = false;
   formattedNames: string[];
 
   constructor() {}

--- a/src/app/projects/projects-list/projects-list.component.html
+++ b/src/app/projects/projects-list/projects-list.component.html
@@ -97,7 +97,7 @@
         <td class="vf-table__cell">{{ project.date }}</td>
         <td class="vf-table__cell">
           <p style="margin-top: 0">{{ project.title }}</p>
-          <app-author-names [authors]="project.authors"></app-author-names>
+          <app-author-names *ngIf="project.authors.length" [authors]="project.authors"></app-author-names>
           <ng-container
             *ngFor="let publication of project.publications"
           >

--- a/src/app/projects/projects.service.ts
+++ b/src/app/projects/projects.service.ts
@@ -64,7 +64,7 @@ export class ProjectsService {
           obj.content.supplementary_links || []
         ),
         publications: obj.publicationsInfo ?? [],
-        authors: obj.content.contributors?.map((author) => {
+        authors: obj.content.contributors.map((author) => {
           const names = author.name.split(',');
           const formattedName = `${
             names[names.length - 1]

--- a/src/app/projects/projects.service.ts
+++ b/src/app/projects/projects.service.ts
@@ -64,7 +64,7 @@ export class ProjectsService {
           obj.content.supplementary_links || []
         ),
         publications: obj.publicationsInfo ?? [],
-        authors: obj.content.contributors.map((author) => {
+        authors: obj.content.contributors?.map((author) => {
           const names = author.name.split(',');
           const formattedName = `${
             names[names.length - 1]


### PR DESCRIPTION
This will hide author-names if there is no authors so that we don't show `undefined et. al`.

For [#352](https://app.zenhub.com/workspaces/dcp-ingest-product-development-5f71ca62a3cb47326bdc1b5c/issues/ebi-ait/dcp-ingest-central/352)

@MightyAx this PR might be of interest to you as some of the imports from your amazing work have some malformed contributors. If you open up the console you can track them down