### PR TITLE
Do not run build_dev in prod pipelines

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,6 +14,8 @@ build_dev:
   stage: build
   tags:
     - dind
+  except:
+    - tags
   script:
     - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN $CI_REGISTRY
     - docker build -t $IMAGE_NAME --build-arg DEPLOYMENT_ENV=staging .


### PR DESCRIPTION
This is a bug in the change for ebi-ait/dcp-ingest-central#333

Job build_dev shouldn't run in prod pipelines

https://gitlab.ebi.ac.uk/ebiwd/html-sites/ebi.ac.uk.humancellatlas.project-catalogue/-/pipelines/164351
