### PR TITLE
Export Search Results

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,17 +15,12 @@ jobs:
         uses: actions/checkout@v2.3.1
         with:
           persist-credentials: false
-      - name: Cache node modules
-        uses: actions/cache@v1
+      - uses: borales/actions-yarn@v2.3.0
         with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+          cmd: install # will run `yarn install` command
+      - uses: borales/actions-yarn@v2.3.0
         with:
-          node-version: ${{ matrix.node-version }}
-      - run: npm install
-      - run: npm run test
-      - run: npm run build
+          cmd: build # will run `yarn build` command
+      - uses: borales/actions-yarn@v2.3.0
+        with:
+          cmd: test # will run `yarn test` command

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,16 +11,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout 🛎️
-        uses: actions/checkout@v2.3.1
+      - uses: actions/checkout@v2
+      - name: Use Node.js
+        uses: actions/setup-node@v1
         with:
-          persist-credentials: false
-      - uses: borales/actions-yarn@v2.3.0
-        with:
-          cmd: install # will run `yarn install` command
-      - uses: borales/actions-yarn@v2.3.0
-        with:
-          cmd: build # will run `yarn build` command
-      - uses: borales/actions-yarn@v2.3.0
-        with:
-          cmd: test # will run `yarn test` command
+          node-version: '12.x'
+      - name: Install dependencies
+        run: yarn --frozen-lockfile
+      - run: yarn build-dev
+      - run: yarn test

--- a/.gitignore
+++ b/.gitignore
@@ -10,12 +10,15 @@
 # dependencies
 /node_modules
 
+# npm lock files, use yarn instead
+package-lock.json
+
 # profiling files
 chrome-profiler-events*.json
 speed-measure-plugin*.json
 
 # IDEs and editors
-/.idea
+.idea
 .project
 .classpath
 .c9/
@@ -46,4 +49,3 @@ testem.log
 Thumbs.db
 
 .cache/
-.idea

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@angular/cli": "~9.1.1",
     "@angular/compiler-cli": "~9.1.1",
     "@angular/language-service": "~9.1.1",
+    "@types/file-saver": "^2.0.2",
     "@types/jasmine": "~3.5.0",
     "@types/jasminewd2": "~2.0.3",
     "codelyzer": "^5.1.2",
@@ -52,6 +53,7 @@
     "@angular/platform-browser": "~9.1.1",
     "@angular/platform-browser-dynamic": "~9.1.1",
     "@angular/router": "~9.1.1",
+    "file-saver": "^2.0.5",
     "rxjs": "~6.5.4",
     "tslib": "^1.10.0",
     "zone.js": "~0.10.2"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@angular/cli": "~9.1.1",
     "@angular/compiler-cli": "~9.1.1",
     "@angular/language-service": "~9.1.1",
-    "@types/file-saver": "^2.0.2",
+    "@types/file-saver": "~2.0.2",
     "@types/jasmine": "~3.5.0",
     "@types/jasminewd2": "~2.0.3",
     "codelyzer": "^5.1.2",

--- a/src/app/projects/projects-list/projects-list.component.html
+++ b/src/app/projects/projects-list/projects-list.component.html
@@ -52,10 +52,15 @@
 </svg>
 
 <ng-container *ngIf="projects; else loading">
-  <p class="vf-text-body vf-text-body--3">
-    Showing <strong>{{ projects.items.length }}</strong> out of
-    <strong>{{ projects.totalItems }}</strong> projects
-  </p>
+  <div style="display: flex; justify-content: space-between">
+    <p class="vf-text-body vf-text-body--3">
+      Showing <strong>{{ projects.items.length }}</strong> out of
+      <strong>{{ projects.totalItems }}</strong> projects
+    </p>
+    <a (click)="saveSearchResultsAsTsv()" class="vf-link" href="javascript:void(0)">
+      Export results as .tsv
+    </a>
+  </div>
 
   <table
     class="vf-table vf-table--sortable vf-table--striped"

--- a/src/app/projects/projects-list/projects-list.component.html
+++ b/src/app/projects/projects-list/projects-list.component.html
@@ -98,7 +98,6 @@
       <tr
         class="vf-table__row"
         *ngFor="let project of projects.items"
-        key="{project.uuid}"
       >
         <td class="vf-table__cell">{{ project.date }}</td>
         <td class="vf-table__cell">

--- a/src/app/projects/projects-list/projects-list.component.ts
+++ b/src/app/projects/projects-list/projects-list.component.ts
@@ -124,7 +124,7 @@ export class ProjectsListComponent implements OnInit, OnDestroy {
   }
 
   private flattenProjectField(key: string, value) {
-    if (value === null || value === false) {
+    if (!value && value !== 0) {
       return '';
     }
     if (key === 'authors') {

--- a/src/app/projects/projects-list/projects-list.component.ts
+++ b/src/app/projects/projects-list/projects-list.component.ts
@@ -108,7 +108,7 @@ export class ProjectsListComponent implements OnInit, OnDestroy {
     const tsvArray = this.projectsAsTsvArray(this.filteredProjects, columns);
     const tsvString = tsvArray.join('\r\n');
     const blob = new Blob([tsvString], {type: 'text/tab-separated-values' });
-    saveAs(blob, 'HumanCellAtlas.tsv');
+    saveAs(blob, 'HcaCatalogueExport.tsv');
   }
 
   private projectsAsTsvArray(projects: Project[], columns: object) {

--- a/src/app/projects/projects-list/projects-list.component.ts
+++ b/src/app/projects/projects-list/projects-list.component.ts
@@ -6,6 +6,7 @@ import { takeUntil } from 'rxjs/operators';
 import { environment } from '../../../environments/environment';
 import { AnalyticsService } from 'src/app/services/analytics.service';
 import { PaginationEvent } from '../components/pagination/pagination.component';
+import { ProjectsTsvService } from '../services/projects-tsv.service';
 import { saveAs } from 'file-saver';
 
 @Component({
@@ -105,37 +106,8 @@ export class ProjectsListComponent implements OnInit, OnDestroy {
       egaStudiesAccessions: 'EGA',
       dcpUrl: 'HCA Data Portal URL'
     };
-    const tsvArray = this.projectsAsTsvArray(this.filteredProjects, columns);
-    const tsvString = tsvArray.join('\r\n');
+    const tsvString = ProjectsTsvService.asTsvString(this.filteredProjects, columns);
     const blob = new Blob([tsvString], {type: 'text/tab-separated-values' });
     saveAs(blob, 'HcaCatalogueExport.tsv');
-  }
-
-  private projectsAsTsvArray(projects: Project[], columns: object) {
-    const tsvArray = projects.map(
-      (project: Project) => this.projectAsTsvString(project, Object.keys(columns))
-    );
-    tsvArray.unshift(Object.values(columns).join('\t'));
-    return tsvArray;
-  }
-
-  private projectAsTsvString(project: Project, keys) {
-    return keys.map(key => this.flattenProjectField(key, project[key])).join('\t');
-  }
-
-  private flattenProjectField(key: string, value) {
-    if (!value && value !== 0) {
-      return '';
-    }
-    if (key === 'authors') {
-      return value.map(author => author.formattedName).join(', ');
-    }
-    if (key === 'publications') {
-      return value.map(publication => `[${publication.journalTitle}](${publication.url})`).join(', ');
-    }
-    if (Array.isArray(value)) {
-      return value.join(', ');
-    }
-    return value;
   }
 }

--- a/src/app/projects/projects-list/projects-list.component.ts
+++ b/src/app/projects/projects-list/projects-list.component.ts
@@ -28,7 +28,7 @@ export class ProjectsListComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit(): void {
-    this.projectService.projects$
+    this.projectService.pagedProjects$
       .pipe(takeUntil(this.unsubscribe$))
       .subscribe((paginatedProjects) => {
         this.projects = paginatedProjects;

--- a/src/app/projects/projects.service.spec.ts
+++ b/src/app/projects/projects.service.spec.ts
@@ -32,7 +32,7 @@ describe('ProjectsService', () => {
 
   it('should return a list of correctly formatted projects', () => {
     const firstProject = testIngestProjects._embedded.projects[0];
-    const sub = service.projects$.subscribe((projects) => {
+    const sub = service.pagedProjects$.subscribe((projects) => {
       const project = projects.items[0];
       const props = [
         'uuid',
@@ -79,7 +79,7 @@ describe('ProjectsService', () => {
   });
 
   it('should return an HTTP error', () => {
-    service.projects$.subscribe(
+    service.pagedProjects$.subscribe(
       (project) => {},
       (error) => {
         expect(error).toBeTruthy();

--- a/src/app/projects/projects.service.ts
+++ b/src/app/projects/projects.service.ts
@@ -29,6 +29,9 @@ export class ProjectsService implements OnDestroy {
   private pagedProjects = new Subject<PaginatedProjects>();
   pagedProjects$ = this.pagedProjects.asObservable();
 
+  private filteredProjects = new Subject<Project[]>();
+  filteredProjects$ = this.filteredProjects.asObservable();
+
   constructor(private http: HttpClient) {
     this.filters = new BehaviorSubject<Filters>({
       organ: '',
@@ -57,6 +60,7 @@ export class ProjectsService implements OnDestroy {
 
   ngOnDestroy(): void {
     this.pagedProjects.complete();
+    this.filteredProjects.complete();
     this.currentPage.complete();
     this.filters.complete();
   }
@@ -89,6 +93,7 @@ export class ProjectsService implements OnDestroy {
             )
           )
         ),
+        tap((projects: Project[]) => this.filteredProjects.next(projects)),
         switchMap((projects: Project[]) =>
           this.currentPage.pipe(
             map((currentPage) => {

--- a/src/app/projects/projects.service.ts
+++ b/src/app/projects/projects.service.ts
@@ -26,8 +26,8 @@ export class ProjectsService implements OnDestroy {
   private filters: BehaviorSubject<Filters>;
   currentFilters: Filters;
 
-  private projects = new Subject<PaginatedProjects>();
-  projects$ = this.projects.asObservable();
+  private pagedProjects = new Subject<PaginatedProjects>();
+  pagedProjects$ = this.pagedProjects.asObservable();
 
   constructor(private http: HttpClient) {
     this.filters = new BehaviorSubject<Filters>({
@@ -56,7 +56,7 @@ export class ProjectsService implements OnDestroy {
   }
 
   ngOnDestroy(): void {
-    this.projects.complete();
+    this.pagedProjects.complete();
     this.currentPage.complete();
     this.filters.complete();
   }
@@ -110,8 +110,8 @@ export class ProjectsService implements OnDestroy {
         )
       )
       .subscribe(
-        (projects) => this.projects.next(projects),
-        (error) => this.projects.error(error)
+        (projects) => this.pagedProjects.next(projects),
+        (error) => this.pagedProjects.error(error)
       );
   }
 

--- a/src/app/projects/services/projects-tsv.service.ts
+++ b/src/app/projects/services/projects-tsv.service.ts
@@ -1,0 +1,35 @@
+import { Project } from '../project';
+
+export class ProjectsTsvService {
+  static asTsvString(projects: Project[], columns: object) {
+    return this.projectsAsTsvArray(projects, columns).join('\r\n');
+  }
+
+  private static projectsAsTsvArray(projects: Project[], columns: object) {
+    const tsvArray = projects.map(
+      (project: Project) => this.projectAsTsvString(project, Object.keys(columns))
+    );
+    tsvArray.unshift(Object.values(columns).join('\t'));
+    return tsvArray;
+  }
+
+  private static projectAsTsvString(project: Project, keys) {
+    return keys.map(key => ProjectsTsvService.flattenProjectField(key, project[key])).join('\t');
+  }
+
+  private static flattenProjectField(key: string, value) {
+    if (!value && value !== 0) {
+      return '';
+    }
+    if (key === 'authors') {
+      return value.map(author => author.formattedName).join(', ');
+    }
+    if (key === 'publications') {
+      return value.map(publication => `[${publication.journalTitle}](${publication.url})`).join(', ');
+    }
+    if (Array.isArray(value)) {
+      return value.join(', ');
+    }
+    return value;
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1173,6 +1173,11 @@
     semver "7.1.3"
     semver-intersect "1.4.0"
 
+"@types/file-saver@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@types/file-saver/-/file-saver-2.0.2.tgz#bd593ccfaee42ff94a5c1c83bf69ae9be83493b9"
+  integrity sha512-xbqnZmGrCEqi/KUzOkeUSe77p7APvLuyellGaAoeww3CHJ1AbjQWjPSCFtKIzZn8L7LpEax4NXnC+gfa6nM7IA==
+
 "@types/glob@^7.1.1":
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.3.tgz#e6ba80f36b7daad2c685acd9266382e68985c183"
@@ -3788,6 +3793,11 @@ file-loader@6.0.0:
   dependencies:
     loader-utils "^2.0.0"
     schema-utils "^2.6.5"
+
+file-saver@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/file-saver/-/file-saver-2.0.5.tgz#d61cfe2ce059f414d899e9dd6d4107ee25670c38"
+  integrity sha512-P9bmyZ3h/PRG+Nzga+rbdI4OEpNDzAVyy74uVO9ATgzLK6VtAsYybF/+TOCvrc0MO793d6+42lLyZTw7/ArVzA==
 
 file-uri-to-path@1.0.0:
   version "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1173,7 +1173,7 @@
     semver "7.1.3"
     semver-intersect "1.4.0"
 
-"@types/file-saver@^2.0.2":
+"@types/file-saver@~2.0.2":
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/@types/file-saver/-/file-saver-2.0.2.tgz#bd593ccfaee42ff94a5c1c83bf69ae9be83493b9"
   integrity sha512-xbqnZmGrCEqi/KUzOkeUSe77p7APvLuyellGaAoeww3CHJ1AbjQWjPSCFtKIzZn8L7LpEax4NXnC+gfa6nM7IA==


### PR DESCRIPTION
Implementation for https://github.com/ebi-ait/dcp-ingest-central/issues/356

- [x] Change project service to include unpaginated filtered projects
- [x] use filtered projects to create flat file
- [x] use TSV format since most of our data contains commas or lists that we usually separate with commas 
- [x] Use Yarn for GitHub builds
- [x] Rename downloaded file to `HcaCatalogueExport.tsv`
 