### PR TITLE
Text fixups

### DIFF
--- a/src/app/pages/about/about.component.ts
+++ b/src/app/pages/about/about.component.ts
@@ -10,8 +10,8 @@ import { HeadingService } from '../../services/heading.service';
 export class AboutComponent {
   constructor(private headingService: HeadingService) {
     this.headingService.setTitle(
-      'Aims, eligibility criteria and selection process',
-      'A comprehensive list of cellular resolution datasets for the Human Cell Atlas.'
+      'About the Catalogue',
+      'Aims, eligibility criteria and selection process'
     );
     this.headingService.setBreadcrumbs('About');
   }

--- a/src/app/projects/pages/projects-list/projects-list.component.html
+++ b/src/app/projects/pages/projects-list/projects-list.component.html
@@ -1,29 +1,3 @@
-<div
-  style="
-    display: flex;
-    width: 100%;
-    flex-wrap: wrap;
-    justify-content: space-between;
-  "
->
-  <p
-    class="vf-text-body vf-text-body--3"
-    style="margin-right: 2rem"
-    style="color: #505050"
-  >
-    A catalogue of single cell projects eligible for the Human Cell Atlas,
-    selected and curated by the HCA DCP wrangling teams.
-    <a routerLink="/about">Read more ></a>
-  </p>
-  <a
-    class="vf-button vf-button--primary vf-button--outline vf-button--sm"
-    style="transform: translateY(-25%); flex-shrink: 0"
-    routerLink="/add-project"
-  >
-    Add a project
-  </a>
-</div>
-
 <app-filters
   *ngIf="projects"
   [organs]="projects.availableOrgans"


### PR DESCRIPTION
- Removes the about page text and button since we have the navigation  now
- work for [#372](https://app.zenhub.com/workspaces/dcp-ingest-product-development-5f71ca62a3cb47326bdc1b5c/issues/ebi-ait/dcp-ingest-central/372)