### PR TITLE
<bugfix dcp-575> Use authors from publicationsInfo

### DIFF
--- a/src/app/projects/components/author-names/author-names.component.ts
+++ b/src/app/projects/components/author-names/author-names.component.ts
@@ -1,23 +1,17 @@
-import { Component, Input, OnInit } from '@angular/core';
-import { Author } from '../../project';
+import { Component, Input } from '@angular/core';
 
 @Component({
   selector: 'app-author-names',
   templateUrl: './author-names.component.html',
   styleUrls: ['./author-names.component.css'],
 })
-export class AuthorNamesComponent implements OnInit {
+export class AuthorNamesComponent {
   @Input()
-  authors: Author[];
+  authors: string[];
 
   fullAuthorView = false;
-  formattedNames: string[];
 
   constructor() {}
-
-  ngOnInit(): void {
-    this.formattedNames = this.authors.map((author) => author.formattedName);
-  }
 
   toggleAuthorView() {
     this.fullAuthorView = !this.fullAuthorView;
@@ -25,7 +19,7 @@ export class AuthorNamesComponent implements OnInit {
 
   getFormattedContributors() {
     return this.fullAuthorView
-      ? this.formattedNames.join(', ')
-      : `${this.formattedNames[0]} et. al.`;
+      ? this.authors.join(', ')
+      : `${this.authors[0]} et. al.`;
   }
 }

--- a/src/app/projects/project.ts
+++ b/src/app/projects/project.ts
@@ -6,11 +6,6 @@ interface Publication {
   authors: string[];
 }
 
-export interface Author {
-  fullName: string;
-  formattedName: string;
-}
-
 export interface Project {
   uuid: string;
   dcpUrl: string;
@@ -27,8 +22,9 @@ export interface Project {
   egaDatasetsAccessions: string[];
   dbgapAccessions: string[];
   publications: Publication[];
-  authors: Author[];
+  authors: string[];
 }
+
 export interface PaginatedList<T> {
   items: T[];
   currentPage: number;

--- a/src/app/projects/services/projects.service.spec.ts
+++ b/src/app/projects/services/projects.service.spec.ts
@@ -58,8 +58,7 @@ describe('ProjectsService', () => {
       });
 
       project.authors.forEach((author) => {
-        expect(author.hasOwnProperty('fullName')).toBeTruthy();
-        expect(author.hasOwnProperty('formattedName')).toBeTruthy();
+        expect(author).toEqual(jasmine.any(String));
       });
 
       project.publications.forEach((publication) => {
@@ -80,7 +79,7 @@ describe('ProjectsService', () => {
     sub.unsubscribe();
   });
 
-  it('should return a correct fullName and formattedName fields', () => {
+  it('each author should be a string containing a space', () => {
     const sub = service.pagedProjects$.subscribe((projects) => {
       expect(projects.items.length).toBeGreaterThan(0);
 
@@ -89,8 +88,8 @@ describe('ProjectsService', () => {
       expect(project).not.toBeNull();
 
       project.authors.forEach((author) => {
-        expect(author.hasOwnProperty('fullName')).toBeTruthy();
-        expect(author.hasOwnProperty('formattedName')).toBeTruthy();
+        expect(author).toEqual(jasmine.any(String));
+        expect(author).toContain(' ');
       });
     });
 

--- a/src/app/projects/services/projects.service.ts
+++ b/src/app/projects/services/projects.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, OnDestroy } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { map, switchMap, tap } from 'rxjs/operators';
+import { uniq, flatten } from 'lodash';
 import { BehaviorSubject, Observable, Subject } from 'rxjs';
 import { environment } from '../../../environments/environment';
 import { PaginatedProjects, Project } from '../project';
@@ -274,27 +275,7 @@ export class ProjectsService implements OnDestroy {
         ),
         dbgapAccessions: obj.content.dbgap_accessions ?? [],
         publications: obj.publicationsInfo ?? [],
-        authors:
-          obj.content.contributors
-            ?.filter((c) => !this.isWrangler(c))
-            .map((author) => {
-              let formattedName = '';
-              let fullName = '';
-              if (author.hasOwnProperty('name')) {
-                const names = author.name.split(',');
-                formattedName = `${
-                  names[names.length - 1]
-                } ${names[0][0].toUpperCase()}`;
-                fullName = author.name;
-              } else if (author.hasOwnProperty('last')) {
-                formattedName = author.last;
-                fullName = author.last;
-              }
-              return {
-                fullName,
-                formattedName,
-              };
-            }) || [],
+        authors: uniq(flatten(obj.publicationsInfo?.map(({ authors }) => authors ))) ?? [],
       };
     } catch (e) {
       console.error(`Error in project ${obj.uuid.uuid}: ${e.message}`);

--- a/src/app/projects/services/projects.service.ts
+++ b/src/app/projects/services/projects.service.ts
@@ -274,7 +274,7 @@ export class ProjectsService implements OnDestroy {
         ),
         dbgapAccessions: obj.content.dbgap_accessions ?? [],
         publications: obj.publicationsInfo ?? [],
-        authors: obj.publicationsInfo[0]?.authors ?? [],
+        authors: obj.publicationsInfo.length ? obj.publicationsInfo[0].authors : [],
       };
     } catch (e) {
       console.error(`Error in project ${obj.uuid.uuid}: ${e.message}`);

--- a/src/app/projects/services/projects.service.ts
+++ b/src/app/projects/services/projects.service.ts
@@ -1,7 +1,6 @@
 import { Injectable, OnDestroy } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { map, switchMap, tap } from 'rxjs/operators';
-import { uniq, flatten } from 'lodash';
 import { BehaviorSubject, Observable, Subject } from 'rxjs';
 import { environment } from '../../../environments/environment';
 import { PaginatedProjects, Project } from '../project';
@@ -275,7 +274,7 @@ export class ProjectsService implements OnDestroy {
         ),
         dbgapAccessions: obj.content.dbgap_accessions ?? [],
         publications: obj.publicationsInfo ?? [],
-        authors: uniq(flatten(obj.publicationsInfo?.map(({ authors }) => authors ))) ?? [],
+        authors: obj.publicationsInfo[0]?.authors ?? [],
       };
     } catch (e) {
       console.error(`Error in project ${obj.uuid.uuid}: ${e.message}`);


### PR DESCRIPTION
dcp-575

- Use `publicationsInfo.authors` instead of `contributors`
- ~There may be more than one publication in `publicationsInfo` but they will likely have the same authors. I have merged and deduped the list. We can change this to use one of the publications in the list if there is issues~ Changed my mind - it now just uses authors from the first publication. The names from each publication can be slightly different (e.g. using middle names in one and the other not) so deduping doesnt work so well