### PR TITLE
Fix bug where pre-citation missing or no publication is not shown

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "@fortawesome/free-solid-svg-icons": "^5.13.0",
     "chart.js": "^2.9.4",
     "file-saver": "^2.0.5",
+    "lodash": "^4.17.21",
     "ng2-charts": "^2.4.2",
     "rxjs": "~6.5.4",
     "tslib": "^2.0.0",

--- a/src/app/projects/services/projects.service.spec.data.json
+++ b/src/app/projects/services/projects.service.spec.data.json
@@ -1,306 +1,164 @@
 {
-  "_embedded": {
-    "projects": [
+  "content": {
+    "describedBy": "https://schema.humancellatlas.org/type/project/14.3.0/project",
+    "schema_type": "project",
+    "project_core": {
+      "project_short_name": "Single cell transcriptome analysis of human pancreas",
+      "project_title": "Single cell transcriptome analysis of human pancreas reveals transcriptional signatures of aging and somatic mutation patterns.",
+      "project_description": "As organisms age, cells accumulate genetic and epigenetic changes that eventually lead to impaired organ function or catastrophic failure such as cancer. Here we describe a single-cell transcriptome analysis of 2544 human pancreas cells from donors, spanning six decades of life. We find that islet cells from older donors have increased levels of disorder as measured both by noise in the transcriptome and by the number of cells which display inappropriate hormone expression, revealing a transcriptional instability associated with aging. By analyzing the spectrum of somatic mutations in single cells from previously-healthy donors, we find a specific age-dependent mutational signature characterized by C to A and C to G transversions, indicators of oxidative stress, which is absent in single cells from human brain tissue or in a tumor cell line. Cells carrying a high load of such mutations also express higher levels of stress and senescence markers, including FOS, JUN, and the cytoplasmic superoxide dismutase SOD1, markers previously linked to pancreatic diseases with substantial age-dependent risk, such as type 2 diabetes mellitus and adenocarcinoma. Thus, our single-cell approach unveils gene expression changes and somatic mutations acquired in aging human tissue, and identifies molecular pathways induced by these genetic changes that could influence human disease. Also, our results demonstrate the feasibility of using single-cell RNA-seq data from primary cells to derive meaningful insights into the genetic processes that operate on aging human tissue and to determine which molecular mechanisms are coordinated with these processes. Examination of single cells from primary human pancreas tissue"
+    },
+    "supplementary_links": [
+      "https://www.ebi.ac.uk/gxa/sc/experiments/E-GEOD-81547/Results"
+    ],
+    "insdc_project_accessions": ["SRP075496"],
+    "geo_series_accessions": ["GSE81547"],
+    "estimated_cell_count": 1000,
+    "publications": [
       {
-        "content": {
-          "describedBy": "https://schema.humancellatlas.org/type/project/14.3.0/project",
-          "schema_type": "project",
-          "project_core": {
-            "project_short_name": "Single cell transcriptome analysis of human pancreas",
-            "project_title": "Single cell transcriptome analysis of human pancreas reveals transcriptional signatures of aging and somatic mutation patterns.",
-            "project_description": "As organisms age, cells accumulate genetic and epigenetic changes that eventually lead to impaired organ function or catastrophic failure such as cancer. Here we describe a single-cell transcriptome analysis of 2544 human pancreas cells from donors, spanning six decades of life. We find that islet cells from older donors have increased levels of disorder as measured both by noise in the transcriptome and by the number of cells which display inappropriate hormone expression, revealing a transcriptional instability associated with aging. By analyzing the spectrum of somatic mutations in single cells from previously-healthy donors, we find a specific age-dependent mutational signature characterized by C to A and C to G transversions, indicators of oxidative stress, which is absent in single cells from human brain tissue or in a tumor cell line. Cells carrying a high load of such mutations also express higher levels of stress and senescence markers, including FOS, JUN, and the cytoplasmic superoxide dismutase SOD1, markers previously linked to pancreatic diseases with substantial age-dependent risk, such as type 2 diabetes mellitus and adenocarcinoma. Thus, our single-cell approach unveils gene expression changes and somatic mutations acquired in aging human tissue, and identifies molecular pathways induced by these genetic changes that could influence human disease. Also, our results demonstrate the feasibility of using single-cell RNA-seq data from primary cells to derive meaningful insights into the genetic processes that operate on aging human tissue and to determine which molecular mechanisms are coordinated with these processes. Examination of single cells from primary human pancreas tissue"
-          },
-          "supplementary_links": [
-            "https://www.ebi.ac.uk/gxa/sc/experiments/E-GEOD-81547/Results"
-          ],
-          "insdc_project_accessions": ["SRP075496"],
-          "geo_series_accessions": ["GSE81547"],
-          "estimated_cell_count": 1000,
-          "publications": [
-            {
-              "authors": [
-                "Enge M",
-                "Arda HE",
-                "Mignardi M",
-                "Beausang J",
-                "Bottino R",
-                "Kim SK",
-                "Quake SR"
-              ],
-              "title": "Single-Cell Analysis of Human Pancreas Reveals Transcriptional Signatures of Aging and Somatic Mutation Patterns.",
-              "doi": "10.1016/j.cell.2017.09.004",
-              "pmid": 28965763,
-              "url": "https://www.ncbi.nlm.nih.gov/pubmed/28965763"
-            }
-          ],
-          "funders": [
-            {
-              "grant_id": "GC1R-06673",
-              "organization": "Institute for Regenerative Medicine"
-            },
-            {
-              "grant_id": "U01-HL099999 and U01-HL099995",
-              "organization": "Center of Excellence for Stem Cell Genomics and NIH"
-            },
-            {
-              "grant_id": "UC4DK104211, DK10261201, and P30DK116074-01",
-              "organization": "NIH"
-            },
-            {
-              "grant_id": "not provided",
-              "organization": "Helmsley Charitable Trust"
-            },
-            {
-              "grant_id": "not provided",
-              "organization": "H.L. Snyder Foundation"
-            },
-            {
-              "grant_id": "not provided",
-              "organization": "Elser Foundation"
-            },
-            {
-              "grant_id": "3-APF-2016-172-A-N",
-              "organization": "JDRF"
-            },
-            {
-              "grant_title": "NIDDK training grant to the Endocrinology Division",
-              "grant_id": "5T32DK007217-39",
-              "organization": "NIDDK"
-            },
-            {
-              "grant_id": "2015-00599",
-              "organization": "Swedish Research Council"
-            },
-            {
-              "grant_id": "2013.0391",
-              "organization": "Wallenberg Research link at Stanford University"
-            }
-          ],
-          "contributors": [
-            {
-              "name": "Martin, Enge",
-              "email": "martin.enge@gmail.com",
-              "institution": "Stanford University",
-              "address": "Bioengineering, Stanford University, James H. Clark Center, 318 Campus Drive,, Stanford, CA, USA",
-              "country": "USA"
-            },
-            {
-              "name": "Laura,,Huerta",
-              "email": "lauhuema@ebi.ac.uk",
-              "institution": "EMBL-EBI",
-              "laboratory": "Molecular Atlas",
-              "address": "Wellcome Trust Genome Campus, Cambridge UK",
-              "country": "UK",
-              "project_role": {
-                "text": "external curator",
-                "ontology": "EFO:0009737",
-                "ontology_label": "data curator"
-              },
-              "orcid_id": "0000-0002-8748-599X",
-              "corresponding_contributor": false
-            },
-            {
-              "name": "Matthew,,Green",
-              "email": "hewgreen@ebi.ac.uk",
-              "phone": "(+44) 122-349-4444",
-              "institution": "EMBL-EBI European Bioinformatics Institute",
-              "laboratory": "Human Cell Atlas Data Coordination Platform",
-              "address": "Wellcome Trust Genome Campus, Hinxton, Cambridge CB10 1SD",
-              "country": "UK",
-              "project_role": {
-                "text": "Human Cell Atlas wrangler",
-                "ontology": "EFO:0009737",
-                "ontology_label": "data curator"
-              },
-              "orcid_id": "0000-0003-2771-9894",
-              "corresponding_contributor": false
-            }
-          ]
-        },
-        "submissionDate": "2019-05-10T14:20:25.934Z",
-        "updateDate": "2021-05-25T14:29:58.603Z",
-        "user": "google-oauth2|105945877951113459382",
-        "lastModifiedUser": "5f91b2f2e72509653db82f6e",
-        "type": "Project",
-        "uuid": {
-          "uuid": "cddab57b-6868-4be4-806f-395ed9dd635a"
-        },
-        "events": [],
-        "firstDcpVersion": "2019-05-10T14:20:25.934Z",
-        "dcpVersion": "2019-05-10T14:20:25.934Z",
-        "contentLastModified": "2021-05-25T14:29:58.601Z",
-        "accession": null,
-        "validationState": "Valid",
-        "validationErrors": [],
-        "isUpdate": false,
-        "releaseDate": null,
-        "accessionDate": null,
-        "technology": null,
-        "organ": null,
-        "dataAccess": null,
-        "identifyingOrganisms": null,
-        "publishedToCatalogue": true,
-        "cataloguedDate": 3,
-        "publicationsInfo": [
-          {
-            "doi": "10.1016/j.cell.2017.09.004",
-            "url": "http://dx.doi.org/10.1016/j.cell.2017.09.004",
-            "journalTitle": "Cell",
-            "title": "Single-Cell Analysis of Human Pancreas Reveals Transcriptional Signatures of Aging and Somatic Mutation Patterns.",
-            "authors": [
-              "Enge M",
-              "Arda HE",
-              "Mignardi M",
-              "Beausang J",
-              "Bottino R",
-              "Kim SK",
-              "Quake SR"
-            ]
-          }
+        "authors": [
+          "Enge M",
+          "Arda HE",
+          "Mignardi M",
+          "Beausang J",
+          "Bottino R",
+          "Kim SK",
+          "Quake SR"
         ],
-        "primaryWrangler": null,
-        "secondaryWrangler": null,
-        "wranglingState": null,
-        "wranglingPriority": 0,
-        "wranglingNotes": null,
-        "hasOpenSubmission": false
+        "title": "Single-Cell Analysis of Human Pancreas Reveals Transcriptional Signatures of Aging and Somatic Mutation Patterns.",
+        "doi": "10.1016/j.cell.2017.09.004",
+        "pmid": 28965763,
+        "url": "https://www.ncbi.nlm.nih.gov/pubmed/28965763"
+      }
+    ],
+    "funders": [
+      {
+        "grant_id": "GC1R-06673",
+        "organization": "Institute for Regenerative Medicine"
       },
       {
-        "content": {
-          "describedBy": "https://schema.humancellatlas.org/type/project/14.3.0/project",
-          "schema_type": "project",
-          "project_core": {
-            "project_short_name": "No pub info",
-            "project_title": "no pub info",
-            "project_description": "As organisms age, cells accumulate genetic and epigenetic changes that eventually lead to impaired organ function or catastrophic failure such as cancer. Here we describe a single-cell transcriptome analysis of 2544 human pancreas cells from donors, spanning six decades of life. We find that islet cells from older donors have increased levels of disorder as measured both by noise in the transcriptome and by the number of cells which display inappropriate hormone expression, revealing a transcriptional instability associated with aging. By analyzing the spectrum of somatic mutations in single cells from previously-healthy donors, we find a specific age-dependent mutational signature characterized by C to A and C to G transversions, indicators of oxidative stress, which is absent in single cells from human brain tissue or in a tumor cell line. Cells carrying a high load of such mutations also express higher levels of stress and senescence markers, including FOS, JUN, and the cytoplasmic superoxide dismutase SOD1, markers previously linked to pancreatic diseases with substantial age-dependent risk, such as type 2 diabetes mellitus and adenocarcinoma. Thus, our single-cell approach unveils gene expression changes and somatic mutations acquired in aging human tissue, and identifies molecular pathways induced by these genetic changes that could influence human disease. Also, our results demonstrate the feasibility of using single-cell RNA-seq data from primary cells to derive meaningful insights into the genetic processes that operate on aging human tissue and to determine which molecular mechanisms are coordinated with these processes. Examination of single cells from primary human pancreas tissue"
-          },
-          "supplementary_links": [
-            "https://www.ebi.ac.uk/gxa/sc/experiments/E-GEOD-81547/Results"
-          ],
-          "insdc_project_accessions": ["SRP075496"],
-          "geo_series_accessions": ["GSE81547"],
-          "estimated_cell_count": 1000,
-          "publications": [
-          ],
-          "funders": [
-          ],
-          "contributors": [
-            {
-              "name": "Martin, Enge",
-              "email": "martin.enge@gmail.com",
-              "institution": "Stanford University",
-              "address": "Bioengineering, Stanford University, James H. Clark Center, 318 Campus Drive,, Stanford, CA, USA",
-              "country": "USA"
-            }
-          ]
-        },
-        "submissionDate": "2019-05-10T14:20:25.934Z",
-        "updateDate": "2021-05-25T14:29:58.603Z",
-        "user": "google-oauth2|105945877951113459382",
-        "lastModifiedUser": "5f91b2f2e72509653db82f6e",
-        "type": "Project",
-        "uuid": {
-          "uuid": "cddab57b-6868-4be4-806f-395ed9dd635a"
-        },
-        "events": [],
-        "firstDcpVersion": "2019-05-10T14:20:25.934Z",
-        "dcpVersion": "2019-05-10T14:20:25.934Z",
-        "contentLastModified": "2021-05-25T14:29:58.601Z",
-        "accession": null,
-        "validationState": "Valid",
-        "validationErrors": [],
-        "isUpdate": false,
-        "releaseDate": null,
-        "accessionDate": null,
-        "technology": null,
-        "organ": null,
-        "dataAccess": null,
-        "identifyingOrganisms": null,
-        "publishedToCatalogue": true,
-        "cataloguedDate": 2,
-        "primaryWrangler": null,
-        "secondaryWrangler": null,
-        "wranglingState": null,
-        "wranglingPriority": 0,
-        "wranglingNotes": null,
-        "hasOpenSubmission": false
+        "grant_id": "U01-HL099999 and U01-HL099995",
+        "organization": "Center of Excellence for Stem Cell Genomics and NIH"
       },
       {
-        "content": {
-          "describedBy": "https://schema.humancellatlas.org/type/project/14.3.0/project",
-          "schema_type": "project",
-          "project_core": {
-            "project_short_name": "No title",
-            "project_description": "As organisms age, cells accumulate genetic and epigenetic changes that eventually lead to impaired organ function or catastrophic failure such as cancer. Here we describe a single-cell transcriptome analysis of 2544 human pancreas cells from donors, spanning six decades of life. We find that islet cells from older donors have increased levels of disorder as measured both by noise in the transcriptome and by the number of cells which display inappropriate hormone expression, revealing a transcriptional instability associated with aging. By analyzing the spectrum of somatic mutations in single cells from previously-healthy donors, we find a specific age-dependent mutational signature characterized by C to A and C to G transversions, indicators of oxidative stress, which is absent in single cells from human brain tissue or in a tumor cell line. Cells carrying a high load of such mutations also express higher levels of stress and senescence markers, including FOS, JUN, and the cytoplasmic superoxide dismutase SOD1, markers previously linked to pancreatic diseases with substantial age-dependent risk, such as type 2 diabetes mellitus and adenocarcinoma. Thus, our single-cell approach unveils gene expression changes and somatic mutations acquired in aging human tissue, and identifies molecular pathways induced by these genetic changes that could influence human disease. Also, our results demonstrate the feasibility of using single-cell RNA-seq data from primary cells to derive meaningful insights into the genetic processes that operate on aging human tissue and to determine which molecular mechanisms are coordinated with these processes. Examination of single cells from primary human pancreas tissue"
-          },
-          "supplementary_links": [
-            "https://www.ebi.ac.uk/gxa/sc/experiments/E-GEOD-81547/Results"
-          ],
-          "insdc_project_accessions": ["SRP075496"],
-          "geo_series_accessions": ["GSE81547"],
-          "estimated_cell_count": 1000,
-          "publications": [
-          ],
-          "funders": [
-          ],
-          "contributors": [
-            {
-              "name": "Martin, Enge",
-              "email": "martin.enge@gmail.com",
-              "institution": "Stanford University",
-              "address": "Bioengineering, Stanford University, James H. Clark Center, 318 Campus Drive,, Stanford, CA, USA",
-              "country": "USA"
-            }
-          ]
+        "grant_id": "UC4DK104211, DK10261201, and P30DK116074-01",
+        "organization": "NIH"
+      },
+      {
+        "grant_id": "not provided",
+        "organization": "Helmsley Charitable Trust"
+      },
+      {
+        "grant_id": "not provided",
+        "organization": "H.L. Snyder Foundation"
+      },
+      {
+        "grant_id": "not provided",
+        "organization": "Elser Foundation"
+      },
+      {
+        "grant_id": "3-APF-2016-172-A-N",
+        "organization": "JDRF"
+      },
+      {
+        "grant_title": "NIDDK training grant to the Endocrinology Division",
+        "grant_id": "5T32DK007217-39",
+        "organization": "NIDDK"
+      },
+      {
+        "grant_id": "2015-00599",
+        "organization": "Swedish Research Council"
+      },
+      {
+        "grant_id": "2013.0391",
+        "organization": "Wallenberg Research link at Stanford University"
+      }
+    ],
+    "contributors": [
+      {
+        "name": "Martin, Enge",
+        "email": "martin.enge@gmail.com",
+        "institution": "Stanford University",
+        "address": "Bioengineering, Stanford University, James H. Clark Center, 318 Campus Drive,, Stanford, CA, USA",
+        "country": "USA"
+      },
+      {
+        "name": "Laura,,Huerta",
+        "email": "lauhuema@ebi.ac.uk",
+        "institution": "EMBL-EBI",
+        "laboratory": "Molecular Atlas",
+        "address": "Wellcome Trust Genome Campus, Cambridge UK",
+        "country": "UK",
+        "project_role": {
+          "text": "external curator",
+          "ontology": "EFO:0009737",
+          "ontology_label": "data curator"
         },
-        "submissionDate": "2019-05-10T14:20:25.934Z",
-        "updateDate": "2021-05-25T14:29:58.603Z",
-        "user": "google-oauth2|105945877951113459382",
-        "lastModifiedUser": "5f91b2f2e72509653db82f6e",
-        "type": "Project",
-        "uuid": {
-          "uuid": "cddab57b-6868-4be4-806f-395ed9dd635a"
+        "orcid_id": "0000-0002-8748-599X",
+        "corresponding_contributor": false
+      },
+      {
+        "name": "Matthew,,Green",
+        "email": "hewgreen@ebi.ac.uk",
+        "phone": "(+44) 122-349-4444",
+        "institution": "EMBL-EBI European Bioinformatics Institute",
+        "laboratory": "Human Cell Atlas Data Coordination Platform",
+        "address": "Wellcome Trust Genome Campus, Hinxton, Cambridge CB10 1SD",
+        "country": "UK",
+        "project_role": {
+          "text": "Human Cell Atlas wrangler",
+          "ontology": "EFO:0009737",
+          "ontology_label": "data curator"
         },
-        "events": [],
-        "firstDcpVersion": "2019-05-10T14:20:25.934Z",
-        "dcpVersion": "2019-05-10T14:20:25.934Z",
-        "contentLastModified": "2021-05-25T14:29:58.601Z",
-        "accession": null,
-        "validationState": "Valid",
-        "validationErrors": [],
-        "isUpdate": false,
-        "releaseDate": null,
-        "accessionDate": null,
-        "technology": null,
-        "organ": null,
-        "dataAccess": null,
-        "identifyingOrganisms": null,
-        "publishedToCatalogue": true,
-        "cataloguedDate": 1,
-        "primaryWrangler": null,
-        "secondaryWrangler": null,
-        "wranglingState": null,
-        "wranglingPriority": 0,
-        "wranglingNotes": null,
-        "hasOpenSubmission": false,
-        "publicationsInfo": [
-          {
-            "doi": "10.1016/j.cell.2017.09.004",
-            "url": "http://dx.doi.org/10.1016/j.cell.2017.09.004",
-            "journalTitle": "Cell",
-            "title": "Single-Cell Analysis of Human Pancreas Reveals Transcriptional Signatures of Aging and Somatic Mutation Patterns.",
-            "authors": [
-              "Enge M",
-              "Arda HE",
-              "Mignardi M",
-              "Beausang J",
-              "Bottino R",
-              "Kim SK",
-              "Quake SR"
-            ]
-          }
-        ]
+        "orcid_id": "0000-0003-2771-9894",
+        "corresponding_contributor": false
       }
     ]
-  }
+  },
+  "submissionDate": "2019-05-10T14:20:25.934Z",
+  "updateDate": "2021-05-25T14:29:58.603Z",
+  "user": "google-oauth2|105945877951113459382",
+  "lastModifiedUser": "5f91b2f2e72509653db82f6e",
+  "type": "Project",
+  "uuid": {
+    "uuid": "cddab57b-6868-4be4-806f-395ed9dd635a"
+  },
+  "events": [],
+  "firstDcpVersion": "2019-05-10T14:20:25.934Z",
+  "dcpVersion": "2019-05-10T14:20:25.934Z",
+  "contentLastModified": "2021-05-25T14:29:58.601Z",
+  "accession": null,
+  "validationState": "Valid",
+  "validationErrors": [],
+  "isUpdate": false,
+  "releaseDate": null,
+  "accessionDate": null,
+  "technology": null,
+  "organ": null,
+  "dataAccess": null,
+  "identifyingOrganisms": null,
+  "publishedToCatalogue": true,
+  "cataloguedDate": 3,
+  "publicationsInfo": [
+    {
+      "doi": "10.1016/j.cell.2017.09.004",
+      "url": "http://dx.doi.org/10.1016/j.cell.2017.09.004",
+      "journalTitle": "Cell",
+      "title": "Single-Cell Analysis of Human Pancreas Reveals Transcriptional Signatures of Aging and Somatic Mutation Patterns.",
+      "authors": [
+        "Enge M",
+        "Arda HE",
+        "Mignardi M",
+        "Beausang J",
+        "Bottino R",
+        "Kim SK",
+        "Quake SR"
+      ]
+    }
+  ],
+  "primaryWrangler": null,
+  "secondaryWrangler": null,
+  "wranglingState": null,
+  "wranglingPriority": 0,
+  "wranglingNotes": null,
+  "hasOpenSubmission": false
 }

--- a/src/app/projects/services/projects.service.spec.ts
+++ b/src/app/projects/services/projects.service.spec.ts
@@ -10,6 +10,10 @@ import { environment } from '../../../environments/environment';
 import testIngestProjects from './projects.service.spec.data.json';
 import cloneDeep from 'lodash/cloneDeep';
 
+/**
+ * Generates a sample list of 1 project to provide to the service
+ * @param mapper (optional) function that receives the sample project and returns a new project. Used to edit the project
+ */
 const makeInputData = (mapper?) => {
   let project = cloneDeep(testIngestProjects);
   if (mapper) {

--- a/src/app/projects/services/projects.service.spec.ts
+++ b/src/app/projects/services/projects.service.spec.ts
@@ -8,6 +8,19 @@ import {
 import { HttpClient } from '@angular/common/http';
 import { environment } from '../../../environments/environment';
 import testIngestProjects from './projects.service.spec.data.json';
+import cloneDeep from 'lodash/cloneDeep';
+
+const makeInputData = (mapper?) => {
+  let project = cloneDeep(testIngestProjects);
+  if (mapper) {
+    project = mapper(project);
+  }
+  return {
+    _embedded: {
+      projects: [project],
+    },
+  };
+};
 
 describe('ProjectsService', () => {
   let service: ProjectsService;
@@ -31,7 +44,8 @@ describe('ProjectsService', () => {
   });
 
   it('should return a list of correctly formatted projects', () => {
-    const firstProject = testIngestProjects._embedded.projects[0];
+    const data = makeInputData();
+    const firstProject = data._embedded.projects[0];
     const sub = service.pagedProjects$.subscribe((projects) => {
       const project = projects.items[0];
       const props = [
@@ -74,7 +88,7 @@ describe('ProjectsService', () => {
       `${environment.ingestApiUrl}${environment.catalogueEndpoint}`
     );
     expect(req.request.method).toEqual('GET');
-    req.flush(testIngestProjects);
+    req.flush(data);
     sub.unsubscribe();
   });
 
@@ -84,7 +98,7 @@ describe('ProjectsService', () => {
 
       const project = projects.items[0];
 
-      expect(project).not.toBeNull();
+      expect(project).toBeDefined();
 
       project.authors.forEach((author) => {
         expect(author).toEqual(jasmine.any(String));
@@ -96,7 +110,7 @@ describe('ProjectsService', () => {
       `${environment.ingestApiUrl}${environment.catalogueEndpoint}`
     );
     expect(req.request.method).toEqual('GET');
-    req.flush(testIngestProjects);
+    req.flush(makeInputData());
     sub.unsubscribe();
   });
 
@@ -122,7 +136,7 @@ describe('ProjectsService', () => {
 
       const project = projects.items[0];
 
-      expect(project).not.toBeNull();
+      expect(project).toBeDefined();
 
       expect(project.cellCount).toEqual(1000);
     });
@@ -131,7 +145,7 @@ describe('ProjectsService', () => {
       `${environment.ingestApiUrl}${environment.catalogueEndpoint}`
     );
     expect(req.request.method).toEqual('GET');
-    req.flush(testIngestProjects);
+    req.flush(makeInputData());
     sub.unsubscribe();
   });
 
@@ -141,9 +155,9 @@ describe('ProjectsService', () => {
     const sub = service.pagedProjects$.subscribe((projects) => {
       expect(projects.items.length).toBeGreaterThan(0);
 
-      const project = projects.items[1];
+      const project = projects.items[0];
 
-      expect(project).not.toBeNull();
+      expect(project).toBeDefined();
 
       expect(console.error).not.toHaveBeenCalledWith(
         jasmine.stringMatching(/authors/)
@@ -155,7 +169,43 @@ describe('ProjectsService', () => {
       `${environment.ingestApiUrl}${environment.catalogueEndpoint}`
     );
     expect(req.request.method).toEqual('GET');
-    req.flush(testIngestProjects);
+
+    const noPublicationsInfo = makeInputData((project) => {
+      delete project.publicationsInfo;
+      return project;
+    });
+
+    req.flush(noPublicationsInfo);
+    sub.unsubscribe();
+  });
+
+  it('should allow empty publicationsInfo', () => {
+    spyOn(console, 'error');
+
+    const sub = service.pagedProjects$.subscribe((projects) => {
+      expect(projects.items.length).toBeGreaterThan(0);
+
+      const project = projects.items[0];
+
+      expect(project).toBeDefined();
+
+      expect(console.error).not.toHaveBeenCalledWith(
+        jasmine.stringMatching(/authors/)
+      );
+      expect(project.authors).toEqual([]);
+    });
+
+    const req = httpTestingController.expectOne(
+      `${environment.ingestApiUrl}${environment.catalogueEndpoint}`
+    );
+    expect(req.request.method).toEqual('GET');
+
+    const emptyPublicationsInfo = makeInputData((project) => {
+      project.publicationsInfo = [];
+      return project;
+    });
+
+    req.flush(emptyPublicationsInfo);
     sub.unsubscribe();
   });
 
@@ -163,10 +213,7 @@ describe('ProjectsService', () => {
     spyOn(console, 'error');
 
     const sub = service.pagedProjects$.subscribe((projects) => {
-      // The project with no title has been filtered out
-      expect(projects.items.length).toEqual(
-        testIngestProjects._embedded.projects.length - 1
-      );
+      expect(projects.items.length).toEqual(0);
 
       expect(console.error).toHaveBeenCalledWith(
         jasmine.stringMatching(/title/)
@@ -177,7 +224,33 @@ describe('ProjectsService', () => {
       `${environment.ingestApiUrl}${environment.catalogueEndpoint}`
     );
     expect(req.request.method).toEqual('GET');
-    req.flush(testIngestProjects);
+
+    const noTitle = makeInputData((project) => {
+      delete project.content.project_core.project_title;
+      return project;
+    });
+    req.flush(noTitle);
+    sub.unsubscribe();
+  });
+
+  it('should allow no authors', () => {
+    const sub = service.pagedProjects$.subscribe((projects) => {
+      const project = projects.items[0];
+      expect(project).toBeDefined();
+      expect(project.authors).toEqual([]);
+    });
+
+    const req = httpTestingController.expectOne(
+      `${environment.ingestApiUrl}${environment.catalogueEndpoint}`
+    );
+
+    expect(req.request.method).toEqual('GET');
+
+    const noAuthors = makeInputData((project) => {
+      delete project.publicationsInfo[0].authors;
+      return project;
+    });
+    req.flush(noAuthors);
     sub.unsubscribe();
   });
 });

--- a/src/app/projects/services/projects.service.ts
+++ b/src/app/projects/services/projects.service.ts
@@ -274,9 +274,7 @@ export class ProjectsService implements OnDestroy {
         ),
         dbgapAccessions: obj.content.dbgap_accessions ?? [],
         publications: obj.publicationsInfo ?? [],
-        authors: obj.publicationsInfo?.length
-          ? obj.publicationsInfo[0].authors || []
-          : [],
+        authors: obj.publicationsInfo?.[0]?.authors || [],
       };
     } catch (e) {
       console.error(`Error in project ${obj.uuid.uuid}: ${e.message}`);

--- a/src/app/projects/services/projects.service.ts
+++ b/src/app/projects/services/projects.service.ts
@@ -274,7 +274,9 @@ export class ProjectsService implements OnDestroy {
         ),
         dbgapAccessions: obj.content.dbgap_accessions ?? [],
         publications: obj.publicationsInfo ?? [],
-        authors: obj.publicationsInfo ? obj.publicationsInfo[0].authors : [],
+        authors: obj.publicationsInfo?.length
+          ? obj.publicationsInfo[0].authors || []
+          : [],
       };
     } catch (e) {
       console.error(`Error in project ${obj.uuid.uuid}: ${e.message}`);


### PR DESCRIPTION
dcp-ops-598 dcp-683

- Fixes bug where projects that don't have `publicationsInfo` are not shown. 
- Adds test to ensure this doesn't happen again
- Refactors test
  - Spec now only contains one project
  - A `makeInputData` function is added to the test suite that uses the spec project, a mapper, and generates a list of projects
  - This is a bit easier to reason about and don't have to keep track of laods of projects in the spec JSON